### PR TITLE
Wrong Number of Frames in SkyreelsVideoPipeline

### DIFF
--- a/skyreelsinfer/pipelines/pipeline_skyreels_video.py
+++ b/skyreelsinfer/pipelines/pipeline_skyreels_video.py
@@ -303,7 +303,7 @@ class SkyreelsVideoPipeline(HunyuanVideoPipeline):
             num_channels_latents,
             height,
             width,
-            num_latent_frames,
+            num_frames,
             torch.float32,
             device,
             generator,


### PR DESCRIPTION
It seems that `num_latent_frames` was incorrectly used in `SkyreelsVideoPipeline` because the number of latent frames is calculated inside the [`prepare_latents`](https://github.com/huggingface/diffusers/blob/7007febae5cff000d4df9059d9cf35133e8b2ca9/src/diffusers/pipelines/hunyuan_video/pipeline_hunyuan_video.py#L405). The current implementation will generate only 25 frames instead of 97 frames.

```python
    def prepare_latents(
        self,
        batch_size: int,
        num_channels_latents: int = 32,
        height: int = 720,
        width: int = 1280,
        num_frames: int = 129,
        dtype: Optional[torch.dtype] = None,
        device: Optional[torch.device] = None,
        generator: Optional[Union[torch.Generator, List[torch.Generator]]] = None,
        latents: Optional[torch.Tensor] = None,
    ) -> torch.Tensor:
        if latents is not None:
            return latents.to(device=device, dtype=dtype)

        shape = (
            batch_size,
            num_channels_latents,
            (num_frames - 1) // self.vae_scale_factor_temporal + 1,
            int(height) // self.vae_scale_factor_spatial,
            int(width) // self.vae_scale_factor_spatial,
        )
        if isinstance(generator, list) and len(generator) != batch_size:
            raise ValueError(
                f"You have passed a list of generators of length {len(generator)}, but requested an effective batch"
                f" size of {batch_size}. Make sure the batch size matches the length of the generators."
            )

        latents = randn_tensor(shape, generator=generator, device=device, dtype=dtype)
        return latents
```